### PR TITLE
fix: include only valid test cases with coords in range [1, 10]

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -11,6 +11,17 @@ def get_test_cases(file_path: str) -> list[str]:
     test_cases = []
 
     for i in range(0, len(cases_parts), 2):
+        countries_string = cases_parts[i + 1]
+
+        coord_pattern = r"\b([1-9]|10)\b"
+        country_tuples = re.findall(
+            fr"(?m)(\w+) {coord_pattern} {coord_pattern} {coord_pattern} {coord_pattern}",
+            countries_string
+        )
+
+        if len(countries_string.strip().splitlines()) != len(country_tuples):
+            continue
+
         test_cases.append(cases_parts[i] + cases_parts[i + 1])
 
     return test_cases


### PR DESCRIPTION
This PR closes the issue #1 

All invalid test cases are skipped. Test case is considered invalid, if there are lines like:
- `France 1 1 100 1`
- `France 1 1 1`
