### PR TITLE
refactor: add missing type-hints

### DIFF
--- a/cities_graph/cities_graph.py
+++ b/cities_graph/cities_graph.py
@@ -13,10 +13,10 @@ class CitiesGraph:
         self.country_names = country_names if country_names is not None else []
         self.city_nodes = city_nodes if city_nodes is not None else {}
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.city_nodes)
 
-    def __setitem__(self, coords: Union[tuple, int], city_node):
+    def __setitem__(self, coords: Union[tuple, int], city_node) -> None:
         if type(coords) == tuple:
             x, y = coords
             city_id = 10 * x + y
@@ -28,7 +28,7 @@ class CitiesGraph:
 
         self.city_nodes[city_id] = city_node
 
-    def __getitem__(self, coords: Union[tuple, int]):
+    def __getitem__(self, coords: Union[tuple, int]) -> CityNode:
         if type(coords) == tuple:
             x, y = coords
             city_id = 10 * x + y
@@ -37,7 +37,7 @@ class CitiesGraph:
 
         return self.city_nodes.get(city_id)
 
-    def __iter__(self):
+    def __iter__(self) -> CitiesGraphIterator:
         return CitiesGraphIterator(self)
 
     @classmethod
@@ -65,12 +65,12 @@ class CitiesGraph:
             name: str,
             xl: Union[str, int], yl: Union[str, int],  # Left bottom corner
             xh: Union[str, int], yh: Union[str, int]   # Right top corner
-    ):
+    ) -> None:
         for x in range(int(xl), int(xh)+1):
             for y in range(int(yl), int(yh)+1):
                 self[x, y] = CityNode(name, self.country_names)
 
-    def get_adjacent_city_ids(self, city_id):
+    def get_adjacent_city_ids(self, city_id: int) -> list[int]:
         possible_adjacent_ids = (city_id - 10,  # North
                                  city_id + 10,  # South
                                  city_id - 1,   # West
@@ -83,7 +83,7 @@ class CitiesGraph:
 
         return adjacent_ids
 
-    def simulate_graph_in_a_one_day(self):
+    def simulate_graph_in_a_one_day(self) -> None:
         city_replenish_portions = defaultdict(lambda: [])  # city_id: list[portions]
         withdraw_portions = {}  # city_id: portion
 

--- a/cities_graph/cities_graph_iter.py
+++ b/cities_graph/cities_graph_iter.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from .cities_graph import CitiesGraph
+    from .cities_graph import CitiesGraph, CityNode
 
 
 class CitiesGraphIterator:
@@ -13,10 +13,10 @@ class CitiesGraphIterator:
         self.visited = set()
         self.queue = [root_id]
 
-    def __iter__(self):
+    def __iter__(self) -> 'CitiesGraphIterator':
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple[int, 'CityNode']:
         if not self.queue:
             raise StopIteration
 

--- a/cities_graph/city_node.py
+++ b/cities_graph/city_node.py
@@ -12,7 +12,7 @@ class CityNode:
 
         self.country = country
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.balance)
 
     def is_complete(self) -> bool:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import time
 
 
-def get_country_cities(case_graph):
+def get_country_cities(case_graph: CitiesGraph) -> dict[str, set]:
     country_cities = defaultdict(lambda: set())
     for city_id, city_node in case_graph:
         country_cities[city_node.country].add(city_id)
@@ -12,13 +12,13 @@ def get_country_cities(case_graph):
 
 
 def update_completed_countries(
-        completed_countries,
-        country_cities,
-        completed_cities,
-        case_results,
-        case_number,
-        current_day
-):
+        completed_countries: set,
+        country_cities: dict[str, set],
+        completed_cities: set,
+        case_results: dict,
+        case_number: int,
+        current_day: int
+) -> None:
     for completed_country in completed_countries:
         country_cities.pop(completed_country)
     completed_countries.clear()
@@ -29,7 +29,7 @@ def update_completed_countries(
             case_results.setdefault(case_number, {})[country_name] = current_day
 
 
-def process_case(case_number, case_text, case_results):
+def process_case(case_number: int, case_text: str, case_results: dict):
     case_graph = CitiesGraph.from_case_text(case_text)
     if not case_graph:
         return


### PR DESCRIPTION
As mentioned in #5 there were missing type hints. This PR adds them for method and function definitions.